### PR TITLE
Single exchange to match frontend

### DIFF
--- a/fetch_source/common.go
+++ b/fetch_source/common.go
@@ -1,10 +1,11 @@
 package fetch_source
+
 import (
 	"bytes"
 	"encoding/json"
 )
 
-type ClientMessage struct {
+type Client_message struct {
 	Type string
 	Data interface{}
 }

--- a/pub/publish_bike_stations.go
+++ b/pub/publish_bike_stations.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -104,11 +105,11 @@ func main() {
 
 	// publish to exchange
 	for i := 0; i < len(station_objs); i++ {
-        var obj fetch_source.ClientMessage
-        obj.Data = station_objs[i]
-        obj.Type = "bikeStatus"		
+		var obj fetch_source.Client_message
+		obj.Data = station_objs[i]
+		obj.Type = "bikeStatus"
 
-        err, content := fetch_source.Encode_to_bytes(obj)
+		err, content := fetch_source.Encode_to_bytes(obj)
 
 		if err != nil {
 			fmt.Println(err.Error())
@@ -116,10 +117,10 @@ func main() {
 		}
 
 		err = ch.PublishWithContext(ctx,
-			"cvst_exchange", // exchange
-			"all.bike.bike_station",   // routing key
-			false,                    // mandatory
-			false,                    // immediate
+			"cvst_exchange",         // exchange
+			"all.bike.bike_station", // routing key
+			false,                   // mandatory
+			false,                   // immediate
 			amqp.Publishing{ // messages to publish
 				ContentType: "text/plain",
 				Body:        content,

--- a/pub/publish_bike_status.go
+++ b/pub/publish_bike_status.go
@@ -105,11 +105,11 @@ func main() {
 
 	// publish to exchange
 	for i := 0; i < len(status_objs); i++ {
-        var obj fetch_source.ClientMessage
-        obj.Data = status_objs[i]
-        obj.Type = "bikeStatus"		
+		var obj fetch_source.Client_message
+		obj.Data = status_objs[i]
+		obj.Type = "bikeStatus"
 
-        err, content := fetch_source.Encode_to_bytes(obj)
+		err, content := fetch_source.Encode_to_bytes(obj)
 
 		if err != nil {
 			fmt.Println(err.Error())
@@ -117,8 +117,8 @@ func main() {
 		}
 
 		err = ch.PublishWithContext(ctx,
-			"cvst_exchange", // exchange
-			"all.bike.bike_status",   // routing key
+			"cvst_exchange",        // exchange
+			"all.bike.bike_status", // routing key
 			false,                  // mandatory
 			false,                  // immediate
 			amqp.Publishing{ // messages to publish

--- a/pub/publish_camera.go
+++ b/pub/publish_camera.go
@@ -110,11 +110,11 @@ func main() {
 
 	// publish to exchange
 	for i := 0; i < len(camera_objs); i++ {
-        var obj fetch_source.ClientMessage
-        obj.Data = camera_objs[i]
-        obj.Type = "camera"		
+		var obj fetch_source.Client_message
+		obj.Data = camera_objs[i]
+		obj.Type = "camera"
 
-        err, content := fetch_source.Encode_to_bytes(obj)
+		err, content := fetch_source.Encode_to_bytes(obj)
 
 		if err != nil {
 			fmt.Println(err.Error())
@@ -123,9 +123,9 @@ func main() {
 
 		err = ch.PublishWithContext(ctx,
 			"cvst_exchange", // exchange
-			"all.camera",   // routing key
-			false,             // mandatory
-			false,             // immediate
+			"all.camera",    // routing key
+			false,           // mandatory
+			false,           // immediate
 			amqp.Publishing{ // messages to publish
 				ContentType: "text/plain",
 				Body:        content,


### PR DESCRIPTION
- Data structure change: added "Type" for frontend to identify data type
- Exchange name: added exchange named "cvst_exchange"
- Use topic binding key "all.{topic}" to make sure routing key sends correct topic to subscribers
- Added helper function in common.go to avoid duplication of Encode_to_bytes